### PR TITLE
Default to bash, minor fixes

### DIFF
--- a/converter.sh
+++ b/converter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Utility script for running ModelClassConverter
 
@@ -35,8 +35,8 @@ then
 fi
 
 echo "converter.sh"
-echo "\tAction: $ACTION"
-echo "\tBranch: $BRANCH"
+printf "\tAction: %s\n", "$ACTION"
+printf "\tBranch: %s\n", "$BRANCH"
 
 
 # Run different actions
@@ -100,7 +100,7 @@ then
 	then
 		
 		# Determine artifacts
-		DEPENDENCIES=`perl -e 'while ($_ = <>) { /<dependency name=\"(.*?)\"/; if ( $t ne $1 ) { print "$1\n"; $t = $1; } }' < $CONFIGURATION`
+		DEPENDENCIES=$(perl -e 'while ($_ = <>) { /<dependency name=\"(.*?)\"/; if ( $t ne $1 ) { print "$1\n"; $t = $1; } }' < "$CONFIGURATION")
 		
 		# Download artifacts
 		for DEPENDENCY in $DEPENDENCIES


### PR DESCRIPTION
`converter.sh` is not compatible with the default system shell on Ubuntu, Dash. It contains constructs that are bash-specific, and as such the "shebang" at the top of the file should be `#!/bin/bash`. This PR addresses that, and makes a few minor changes to remove deprecated constructs and to achieve proper formatting.

Tested on both Ubuntu (20.0.4) and MacOS (BIg Sur)