### PR TITLE
Fix erronous override keyword

### DIFF
--- a/converter.sh
+++ b/converter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Utility script for running ModelClassConverter
 
@@ -35,8 +35,8 @@ then
 fi
 
 echo "converter.sh"
-echo "\tAction: $ACTION"
-echo "\tBranch: $BRANCH"
+printf "\tAction: %s\n", "$ACTION"
+printf "\tBranch: %s\n", "$BRANCH"
 
 
 # Run different actions
@@ -100,7 +100,7 @@ then
 	then
 		
 		# Determine artifacts
-		DEPENDENCIES=`perl -e 'while ($_ = <>) { /<dependency name=\"(.*?)\"/; if ( $t ne $1 ) { print "$1\n"; $t = $1; } }' < $CONFIGURATION`
+		DEPENDENCIES=$(perl -e 'while ($_ = <>) { /<dependency name=\"(.*?)\"/; if ( $t ne $1 ) { print "$1\n"; $t = $1; } }' < "$CONFIGURATION")
 		
 		# Download artifacts
 		for DEPENDENCY in $DEPENDENCIES

--- a/templates/SwiftLemonClass.ftl
+++ b/templates/SwiftLemonClass.ftl
@@ -1,10 +1,10 @@
-//  
+//
 //  ${file_name}
 //  ${entity_identifier}
 //  ${product_name} (${model_version})
-//  
+//
 //  Automatically generated on ${file_date} at ${file_time} by ${user}.
-//  
+//
 
 import Lemon
 
@@ -25,7 +25,7 @@ ${parameter.parameter_literal}<#t><#sep>, </#sep></#list>> </#if>: <#if class_pa
 	
 	// MARK: - Properties
 	
-	public override class var descriptor : String {
+	public <#if class_parent??>override </#if>class var descriptor : String {
 		return "${entity_descriptor}"
 	}
 	<#list class_properties><#t>


### PR DESCRIPTION
Whenever a model class does not have a defined superclass (such as Linkable) it still gets the following property:

```swift
public override class var descriptor : String {
  return "my.RModelClass"
}
```
This causes the following compiler error: `Property does not override any property from its superclass`

To remedy this, I've modified the template to omit the `override` keyword if no superclass is known.

This PR incorporates [PR 5](https://github.com/topicusonderwijs/ModelClassConverter/pull/5)